### PR TITLE
build/ops: rpm: conditionalize libradosstriper

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -25,6 +25,7 @@
 %bcond_without selinux
 %bcond_without ceph_test_package
 %bcond_without cephfs_java
+%bcond_without libradosstriper
 %bcond_without lttng
 %global _remote_tarball_prefix https://download.ceph.com/tarballs/
 %endif
@@ -37,8 +38,10 @@
 %global _fillupdir /var/adm/fillup-templates
 %endif
 %if 0%{?is_opensuse}
+%bcond_without libradosstriper
 %bcond_without lttng
 %else
+%bcond_with libradosstriper
 %ifarch x86_64 aarch64
 %bcond_without lttng
 %else
@@ -295,6 +298,9 @@ Group:		System/Filesystems
 %endif
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
+%if 0%{with libradosstriper}
+Requires:	libradosstriper1 = %{_epoch_prefix}%{version}-%{release}
+%endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{_python_buildid}-rados = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{_python_buildid}-rbd = %{_epoch_prefix}%{version}-%{release}
@@ -566,6 +572,7 @@ Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 This package contains Python 3 libraries for interacting with Cephs RADOS
 object store.
 
+%if 0%{with libradosstriper}
 %package -n libradosstriper1
 Summary:	RADOS striping interface
 %if 0%{?suse_version}
@@ -590,6 +597,7 @@ Obsoletes:	libradosstriper1-devel < %{_epoch_prefix}%{version}-%{release}
 %description -n libradosstriper-devel
 This package contains libraries and headers needed to develop programs
 that use RADOS striping interface.
+%endif
 
 %package -n librbd1
 Summary:	RADOS block device client library
@@ -922,6 +930,11 @@ cmake .. \
     -DWITH_BOOST_CONTEXT=ON \
 %else
     -DWITH_BOOST_CONTEXT=OFF \
+%endif
+%if 0%{with libradosstriper}
+    -DWITH_LIBRADOSSTRIPER=ON \
+%else
+    -DWITH_LIBRADOSSTRIPER=OFF \
 %endif
     -DBOOST_J=$CEPH_SMP_NCPUS
 
@@ -1615,6 +1628,7 @@ fi
 %{python3_sitearch}/rados.cpython*.so
 %{python3_sitearch}/rados-*.egg-info
 
+%if 0%{with libradosstriper}
 %files -n libradosstriper1
 %{_libdir}/libradosstriper.so.*
 
@@ -1627,6 +1641,7 @@ fi
 %{_includedir}/radosstriper/libradosstriper.h
 %{_includedir}/radosstriper/libradosstriper.hpp
 %{_libdir}/libradosstriper.so
+%endif
 
 %files -n librbd1
 %{_libdir}/librbd.so.*


### PR DESCRIPTION
Enable downstreams (such as SLE) to not ship libradosstriper.

Fixes: https://tracker.ceph.com/issues/22750
Signed-off-by: Nathan Cutler <ncutler@suse.com>